### PR TITLE
Fix: Font Scaling condition flipped & more

### DIFF
--- a/fastpng/main.py
+++ b/fastpng/main.py
@@ -90,7 +90,7 @@ async def generate_image(imageRequest: ImageRequest):
         class ImageRequest {
             font (str): The font name from /fonts
             text (str): The text to be displayed
-            fontColour (str, optional): Colour of font in HEX. Defaults to "FFFFFF" (White).
+            fontColor (str, optional): Color of font in HEX. Defaults to "FFFFFF" (White).
             fontSize (int, optional): The font size in pixels. Defaults to 40.
             width (int, optional): The Image width in pixels. Defaults to 512.
             height (int, optional): The Image height in pixels. Defaults to 512.
@@ -139,13 +139,20 @@ async def generate_image(imageRequest: ImageRequest):
 
     buffer = io.BytesIO()
     image.save(buffer, format="PNG")
-    buffer.seek(0)
-    img_str = "data:image/png;base64," + base64.b64encode(buffer.getvalue()).decode()
+
+    # bytes
+    result = buffer.getvalue()
+
+    # Base 64 Alternative
+    # buffer.seek(0)
+    # result = "data:image/png;base64," + base64.b64encode(buffer.getvalue()).decode()
+
     end_time = time.time()
     logger.info(f"Time taken: {end_time - start_time} seconds")
+
     return Response(
-        img_str,
-        media_type="data:image/png;base64",
+        result,
+        media_type="image/png",
         headers={
             "x-time-taken": f"{end_time-start_time}",
             "x-image-size": f"{imageRequest.width}x{imageRequest.height}",

--- a/fastpng/main.py
+++ b/fastpng/main.py
@@ -4,12 +4,11 @@
 
 from fastapi import FastAPI
 from fastapi.responses import Response
-from pydantic import BaseModel
 
 import io
 import time
 import math
-import base64
+
 from PIL import Image, ImageDraw, ImageFont
 from matplotlib import font_manager
 
@@ -71,40 +70,31 @@ def read_fonts():
     # sorted_font_keys = sorted(font_keys)
     # return sorted_font_keys
     return sorted(list(font_mapping.keys()))
-
-class ImageRequest(BaseModel):
-    font: str
-    text: str
-    fontColor: str = "FFFFFF"
-    fontSize: int= 40
-    width: int = 512
-    height: int = 512
-    offsetX: int = 256
-    offsetY: int = 256
    
-@app.post("/generate-image", responses={200: {"content": {"image/png": {}}}})
-async def generate_image(imageRequest: ImageRequest):
+@app.get("/generate-image", responses={200: {"content": {"image/png": {}}}})
+async def generate_image(font: str, text: str, font_color: str= "FFFFFF", font_size: int=40, width: int = 512, height: int = 512, offset_x: int = 256, offset_y: int = 256, anchor: str = "mm"):
     """Generates an image with the given text and font
 
     Args:
         class ImageRequest {
             font (str): The font name from /fonts
             text (str): The text to be displayed
-            fontColor (str, optional): Color of font in HEX. Defaults to "FFFFFF" (White).
-            fontSize (int, optional): The font size in pixels. Defaults to 40.
+            font_color (str, optional): Color of font in HEX. Defaults to "FFFFFF" (White).
+            font_size (int, optional): The font size in pixels. Defaults to 40.
             width (int, optional): The Image width in pixels. Defaults to 512.
             height (int, optional): The Image height in pixels. Defaults to 512.
-            offsetX (int, optional): The position in pixels the anchor will offset from along the x-axis. Defaults to 256.
-            offsetY (int, optional): The position in pixels the anchor will offset from along the y-axis. Defaults to 256.
+            offset_x (int, optional): The position in pixels the anchor will offset from along the x-axis. Defaults to 256.
+            offset_y (int, optional): The position in pixels the anchor will offset from along the y-axis. Defaults to 256.
+            anchor (str, optional): The anchoring type around the (x,y) offset. See https://pillow.readthedocs.io/en/stable/handbook/text-anchors.html
         }
 
     Returns:
         File: The generated PNG file
     """    
-    if imageRequest.font not in font_mapping:
+    if font not in font_mapping:
         return {"error": "Font not found"}
     
-    sanitized_font_colour = imageRequest.fontColor.lstrip("#")
+    sanitized_font_colour = font_color.lstrip("#")
 
     # check that font_colour is a valid hex code
     if not all(c in "0123456789ABCDEF" for c in sanitized_font_colour):
@@ -112,30 +102,30 @@ async def generate_image(imageRequest: ImageRequest):
 
     start_time = time.time()
 
-    image = Image.new("RGBA", (imageRequest.width, imageRequest.height), (0, 0, 0, 0))
+    image = Image.new("RGBA", (width, height), (0, 0, 0, 0))
 
-    # logger.debug(f"Font: {imageRequest.font}, Text: {imageRequest.text}")
-    optimal_font_size = imageRequest.fontSize
+    # logger.debug(f"Font: {font}, Text: {text}")
+    optimal_font_size = font_size
 
-    font_file = ImageFont.truetype(font_mapping[imageRequest.font], optimal_font_size)
+    font_file = ImageFont.truetype(font_mapping[font], optimal_font_size)
 
-    text_length = font_file.getlength(imageRequest.text)
+    text_length = font_file.getlength(text)
     
-    ratio = imageRequest.width * 0.97 / text_length
+    ratio = width * 0.97 / text_length
 
     if ratio < 1:
         optimal_font_size = math.floor(optimal_font_size * ratio)    
     
-    # logger.debug(f"Text Length: {textLength}, Ratio: {ratio}, Font Size: {imageRequest.font_size}")
+    # logger.debug(f"Text Length: {textLength}, Ratio: {ratio}, Font Size: {font_size}")
 
-    font_file = ImageFont.truetype(font_mapping[imageRequest.font], optimal_font_size)
+    font_file = ImageFont.truetype(font_mapping[font], optimal_font_size)
 
     # convert font_colour hex code to tuple
     font_colour_tuple = tuple(int(sanitized_font_colour[i:i+2], 16) for i in (0, 2, 4))
 
     draw = ImageDraw.Draw(image)
 
-    draw.text((imageRequest.offsetX, imageRequest.offsetY), imageRequest.text, font=font_file, fill=font_colour_tuple, anchor="mm")
+    draw.text((offset_x, offset_y), text, font=font_file, fill=font_colour_tuple, anchor=anchor)
 
     buffer = io.BytesIO()
     image.save(buffer, format="PNG")
@@ -155,7 +145,7 @@ async def generate_image(imageRequest: ImageRequest):
         media_type="image/png",
         headers={
             "x-time-taken": f"{end_time-start_time}",
-            "x-image-size": f"{imageRequest.width}x{imageRequest.height}",
+            "x-image-size": f"{width}x{height}",
             "x-font-size": f"{optimal_font_size}",
         },
     )

--- a/fastpng/main.py
+++ b/fastpng/main.py
@@ -73,7 +73,7 @@ def read_fonts():
 
 
 @app.get("/generate_image", responses={200: {"content": {"image/png": {}}}})
-async def generate_image(font: str, text: str, font_colour: str= "FFFFFF", font_size: int=40, offset_x: int = None, offset_y: int = None):
+async def generate_image(font: str, text: str, font_colour: str= "FFFFFF", font_size: int=40, offset_x: int = 256, offset_y: int = 256, width: int = 512, height: int = 512):
     """Generates an image with the given text and font
 
     Args:
@@ -95,7 +95,7 @@ async def generate_image(font: str, text: str, font_colour: str= "FFFFFF", font_
 
 
     start_time = time.time()
-    image = Image.new("RGBA", (512, 512), (255, 255, 255, 255))
+    image = Image.new("RGBA", (width, height), (0, 0, 0, 0))
     # font_size = 40
     logger.debug(f"Font: {font}, Text: {text}")
     font_file = ImageFont.truetype(font_mapping[font], font_size)
@@ -113,11 +113,11 @@ async def generate_image(font: str, text: str, font_colour: str= "FFFFFF", font_
     # ratio = 500 / textLength # ratio is fixed width of 500 divided by the pixel length
     ratio = image_size[1] * 0.97 / textLength
 
-    # if ratio < 1: # less than
-    #     font_size = math.floor(font_size * (1 + ratio))
-    #     logger.debug(f"font size is: {font_size}")
-    if ratio > 1: # greater than
+    if ratio < 1: # less than
         font_size = math.floor(font_size * ratio)
+    #     logger.debug(f"font size is: {font_size}")
+    # if ratio > 1: # greater than
+    #   font_size = math.floor(font_size * (1 + ratio))
     
     
     logger.debug(f"Text Length: {textLength}, Ratio: {ratio}, Font Size: {font_size}")
@@ -128,8 +128,8 @@ async def generate_image(font: str, text: str, font_colour: str= "FFFFFF", font_
     font_colour_tuple = tuple(int(font_colour[i:i+2], 16) for i in (0, 2, 4))
 
     draw = ImageDraw.Draw(image)
-    offset = (image_size[0] / 2, image_size[1] / 2) if offset_x is None and offset_y is None else (offset_x, offset_y)
-    draw.text(offset, text, font=font_file, fill=font_colour_tuple, anchor="mm")
+    # offset = (image_size[0] / 2, image_size[1] / 2) if offset_x is None and offset_y is None else (offset_x, offset_y)
+    draw.text((offset_x, offset_y), text, font=font_file, fill=font_colour_tuple, anchor="mm")
 
     buffer = io.BytesIO()
     image.save(buffer, format="PNG")

--- a/fastpng/main.py
+++ b/fastpng/main.py
@@ -72,7 +72,7 @@ def read_fonts():
     return sorted(list(font_mapping.keys()))
    
 @app.get("/generate-image", responses={200: {"content": {"image/png": {}}}})
-async def generate_image(font: str, text: str, font_color: str= "FFFFFF", font_size: int=40, width: int = 512, height: int = 512, offset_x: int = 256, offset_y: int = 256, anchor: str = "mm"):
+async def generate_image(font: str, text: str, font_color: str = "FFFFFF", font_size: int = 40, width: int = 512, height: int = 512, offset_x: int = 256, offset_y: int = 256, anchor: str = "mm"):
     """Generates an image with the given text and font
 
     Args:


### PR DESCRIPTION
- Fix: Font scaling math now is less instead of greater than
- Fix: Set Image alpha channel to 0.
- Set Image rgb channels to black as well, for pixel rounding errors, fringing.
- Set offset with initial values
- Add width and height to generate_image params